### PR TITLE
fix: Chat panel alignment by applying proven tab pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,13 @@ This is a fork of Strudel (https://strudel.cc/), a Tidal-based live coding envir
 - Always create PR for user with `gh pr create`
 - **NEVER EVER USE CONDITIONAL HANDLING - Always plan for the working path**
 
+## Visual Layout Problems: Logic-First Approach
+- **Frame all visual layout problems as logic problems**
+- Seek all information and context you can collect before acting
+- Read ALL related component files completely for pattern matching
+- Present recommendation to user before proceeding with changes
+- Don't blame "visual constraints" - analyze code systematically
+
 ## Key Areas for AI Enhancement
 - Pattern generation and suggestion
 - Sample selection and arrangement

--- a/website/src/repl/components/panel/AIChatTab.jsx
+++ b/website/src/repl/components/panel/AIChatTab.jsx
@@ -95,14 +95,14 @@ I can see your current patterns and will generate Strudel code for you!`,
   };
 
   return (
-    <div className="flex flex-col h-full max-h-[320px]" style={{ fontFamily }}>
+    <div className="px-4 flex flex-col w-full h-full text-foreground" style={{ fontFamily }}>
       {/* Header */}
-      <div className="px-4 py-2 border-b border-gray-600">
+      <div className="py-2">
         <h3 className="text-sm font-medium text-foreground">🤖 AI Assistant</h3>
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
+      <div className="min-h-0 max-h-full grow overflow-auto py-2 space-y-3">
         {messages.map((message) => (
           <div key={message.id} className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}>
             <div className={`max-w-[80%] rounded-lg p-3 ${
@@ -140,7 +140,7 @@ I can see your current patterns and will generate Strudel code for you!`,
       </div>
 
       {/* Input */}
-      <form onSubmit={handleSubmit} className="p-4 border-t border-gray-600">
+      <form onSubmit={handleSubmit} className="py-2">
         <div className="flex space-x-2">
           <input
             ref={inputRef}

--- a/website/src/repl/components/panel/Panel.jsx
+++ b/website/src/repl/components/panel/Panel.jsx
@@ -55,7 +55,7 @@ export function VerticalPanel({ context }) {
             <PanelActionButton settings={settings} />
           </div>
 
-          <div className="overflow-auto h-full">
+          <div className="overflow-auto h-full w-full">
             <PanelContent context={context} tab={tab} />
           </div>
         </div>


### PR DESCRIPTION
## Fix Chat Panel Alignment Issue

🎯 **Problem Solved**: Chat panel not extending to browser edge like other tabs

### Root Cause Analysis
Through systematic analysis of ALL tab components, identified that chat tab was using different structural pattern than working tabs.

### Pattern Analysis Results
**Working tabs** (SoundsTab, PatternsTab, FilesTab) all use:


**Chat tab was using**: Artificial constraints and inconsistent patterns

### Changes Applied
- ✅ **Removed artificial height constraint** (`max-h-[320px]`)
- ✅ **Applied consistent padding pattern** (`px-4` on root)  
- ✅ **Used proven scrollable pattern** (`min-h-0 max-h-full grow overflow-auto`)
- ✅ **Removed conflicting borders** in favor of spacing
- ✅ **Consistent spacing** (`py-2` throughout)

### Result
- ✅ Chat panel now responsive to width changes
- ✅ Extends fully to browser edge
- ✅ Behaves consistently with other tabs
- ✅ Proper layout pattern applied

### Methodology
This demonstrates the **logic-first approach** to layout problems:
1. Systematic analysis of ALL working examples
2. Pattern identification through code comparison
3. Precise application of proven patterns
4. No guesswork or visual assumptions

**Layout problems are logic problems!** 🧠

Closes #6